### PR TITLE
chore: add commitizen config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Babel Preset for CA Technologies
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 ` npm install --save babel-preset-ca `
+
 
 ### Usage
 
@@ -11,3 +13,11 @@ Add the following line to your .babelrc file:
   "presets": ["ca"]
 }
 ```
+
+
+## Contributing
+
+This project supports `commitizen`. You can use `npm run commit` to run the local instance of `commitizen` or `git cz` if you have it installed globally.
+
+Alternatively, if you are simply using `git commit`, you must follow this format:
+`git commit -m "<type>: <subject>"`

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Babel preset for CA",
   "author": "Bevan Hunt <bevan.hunt@ca.com>",
   "license": "MIT",
+  "scripts": {
+    "commitmsg": "validate-commit-msg",
+    "commit": "git-cz"
+  },
   "repository": "https://github-isl-01.ca.com/APIM-WEB/babel-preset-ca",
   "main": "index.js",
   "dependencies": {
@@ -13,5 +17,19 @@
     "babel-plugin-transform-object-rest-spread": "^6.19.0",
     "babel-preset-latest": "^6.16.0",
     "babel-preset-react": "^6.16.0"
+  },
+  "devDependencies": {
+    "commitizen": "^2.8.6",
+    "cz-conventional-changelog": "^1.2.0",
+    "husky": "^0.11.9",
+    "validate-commit-msg": "^2.8.2"
+  },
+  "config": {
+    "validate-commit-msg": {
+      "types": "conventional-commit-types"
+    },
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
This Commit adds `commitizen`, `validate-commit-msg` and `cz-conventional-changelog` functionality to this repo, as per https://rally1.rallydev.com/#/63515825210ud/detail/userstory/78741891276

Commit messages for this project will now have to be structured in this format:
`git commit -m "<type>: <subject>"`

e.g. `git commit -m "chore: add commitizen adapter"`

CC: @alebiavati @shanedasilva @bevanhunt