### PR TITLE
Update deprecated dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-var latest = require('babel-preset-latest');
+var env = require('babel-preset-env');
 var react = require('babel-preset-react');
 
 var transformDoExpressions = require('babel-plugin-transform-do-expressions');
@@ -15,7 +15,7 @@ var transformSpread = require('babel-plugin-transform-object-rest-spread');
 
 module.exports = {
   presets: [
-    latest,
+    env,
     react
   ],
   plugins: [

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-do-expressions": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.19.0",
-    "babel-preset-latest": "^6.16.0",
+    "babel-preset-env": "^1.2.2",
     "babel-preset-react": "^6.16.0"
   },
   "devDependencies": {
     "babel-core": "^6.21.0",
     "chalk": "^1.1.3",
     "commitizen": "^2.8.6",
-    "cz-conventional-changelog": "^1.2.0",
-    "husky": "^0.11.9",
+    "cz-conventional-changelog": "^2.0.0",
+    "husky": "^0.13.3",
     "react": "^15.4.2",
     "validate-commit-msg": "^2.8.2",
     "semantic-release": "^6.3.2"

--- a/tests/input.js
+++ b/tests/input.js
@@ -27,7 +27,7 @@ function dec(id){
 
 // class decorators and properties
 class Foobar {
-  @dec(1);
+  @dec(1)
   static foo = 1;
 }
 


### PR DESCRIPTION
## Status
**READY**

## Description
`babel-preset-latest` was giving the following warning:

```
npm WARN deprecated babel-preset-latest@6.16.0: 💥  preset-latest accomplishes the same task as babel-preset-env. 🙏  Please install it with 'npm install babel-preset-env --save-dev'. '{ "presets": ["latest"] }' to '{ "presets": ["env"] }'. For more info, please check the docs: http://babeljs.io/docs/plugins/preset-env
```

This PR updates the package to use `babel-preset-env`.
Merging will trigger a minor version update.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* `package.json`
* `index.js`
* fixed test: new babel preset doesn't allow decorators to be followed by semicolons (just like in spec).
