### PR TITLE
fix: remove babel-preset-env and add babel-preset-es2015/es2016/es2017

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-var env = require('babel-preset-env');
+var es2015 = require('babel-preset-es2015');
+var es2016 = require('babel-preset-es2016');
+var es2017 = require('babel-preset-es2017');
 var react = require('babel-preset-react');
 
 var transformDoExpressions = require('babel-plugin-transform-do-expressions');
@@ -15,7 +17,9 @@ var transformSpread = require('babel-plugin-transform-object-rest-spread');
 
 module.exports = {
   presets: [
-    env,
+    es2015,
+    es2016,
+    es2017,
     react
   ],
   plugins: [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-do-expressions": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.19.0",
-    "babel-preset-env": "^1.2.2",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-es2016": "^6.22.0",
+    "babel-preset-es2017": "^6.22.0",
     "babel-preset-react": "^6.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Status
**READY**

## Description
`babel-preset-env` is breaking projects using this package, so we're switching it out in favour of `babel-preset-es2015`, `babel-preset-es2016` and `babel-preset-es2017`.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* `index.js`
* `package.json`