### PR TITLE
fix: Try bumping babel-loader-core version, + removed extra dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.19.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-env": "^1.6.1",
-    "babel-core": "^6.21.0",
-    "react": "^15.6.1",
+    "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Status
**READY**

## Description
Testing to see if bumping `babel-core` version to latest will make a difference. This didn't work locally for me but just to make sure this isn't due to a faulty `npm link`, I want to cut a new version and try here.

## Impacted Areas in Application
* `package.json`
